### PR TITLE
Errors when spaces are present before/after bool values in the yaml files.

### DIFF
--- a/resources/multiple_elements.yml
+++ b/resources/multiple_elements.yml
@@ -1,0 +1,9 @@
+elements:
+  - name: Example Name 
+    bool_val: true
+    int_val: 0 
+    float_val: 3.14
+  - name: Example Name 2
+    bool_val: false 
+    int_val: 120  
+    float_val: 56.123

--- a/resources/yaml-test-suite/98YD-mixed.yml
+++ b/resources/yaml-test-suite/98YD-mixed.yml
@@ -9,3 +9,6 @@ elemennts:
       -STR
     json: ""
     dump: ""
+    bool_val: true
+    bool_val_b2: false
+    bool_val_with_spaces: true  

--- a/resources/yaml-test-suite/98YD.yml
+++ b/resources/yaml-test-suite/98YD.yml
@@ -9,3 +9,6 @@ elemennts:
       -STR
     json: ""
     dump: ""
+    bool_val: true
+    bool_val_b2: false
+    bool_val_with_spaces: true  

--- a/resources/yaml-test-suite/multiple_elements.yml
+++ b/resources/yaml-test-suite/multiple_elements.yml
@@ -1,0 +1,5 @@
+elemennts:
+  - name: Example Name 
+    bool_val: true
+  - name: Example Name 2
+    bool_val: false 

--- a/resources/yaml-test-suite/multiple_elements.yml
+++ b/resources/yaml-test-suite/multiple_elements.yml
@@ -1,5 +1,0 @@
-elemennts:
-  - name: Example Name 
-    bool_val: true
-  - name: Example Name 2
-    bool_val: false 

--- a/src/root.zig
+++ b/src/root.zig
@@ -421,11 +421,13 @@ pub fn Ymlz(comptime Destination: type) type {
             _ = self;
 
             // Trim spaces from value
-            return std.mem.trim(u8, switch (expression.value) {
+            const value = switch (expression.value) {
                 .Simple => expression.value.Simple,
                 .KV => expression.value.KV.value,
                 else => @panic("Not implemeted for " ++ @typeName(@TypeOf(expression.value))),
-            }, " ");
+            };
+
+            return std.mem.trim(u8, value, " ");
         }
 
         fn getExpressionValue(self: *Self, expression: Expression) []const u8 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -454,7 +454,9 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseNumericExpression(self: *Self, comptime T: type, raw_line: []const u8, depth: usize) !T {
             const expression = try self.parseSimpleExpression(raw_line, depth, false);
-            const value = self.getExpressionValue(expression);
+            var value = self.getExpressionValue(expression);
+
+            value = std.mem.trim(u8, value, " ");
 
             switch (@typeInfo(T)) {
                 .Int => {

--- a/src/root.zig
+++ b/src/root.zig
@@ -418,16 +418,7 @@ pub fn Ymlz(comptime Destination: type) type {
         }
 
         fn getExpressionValueWithTrim(self: *Self, expression: Expression) []const u8 {
-            _ = self;
-
-            // Trim spaces from value
-            const value = switch (expression.value) {
-                .Simple => expression.value.Simple,
-                .KV => expression.value.KV.value,
-                else => @panic("Not implemeted for " ++ @typeName(@TypeOf(expression.value))),
-            };
-
-            return std.mem.trim(u8, value, " ");
+            return std.mem.trim(u8, self.getExpressionValue(expression), " ");
         }
 
         fn getExpressionValue(self: *Self, expression: Expression) []const u8 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -372,7 +372,10 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseStringExpression(self: *Self, raw_line: []const u8, depth: usize, is_multiline: bool) ![]const u8 {
             const expression = try self.parseSimpleExpression(raw_line, depth, is_multiline);
-            const value = self.getExpressionValue(expression);
+            var value = self.getExpressionValue(expression);
+
+            // Trim spaces to avoid errors when placing spaces after strings in the yaml
+            value = std.mem.trim(u8, value, " ");
 
             if (value.len == 0) return value;
 
@@ -429,7 +432,10 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseBooleanExpression(self: *Self, raw_line: []const u8, depth: usize) !bool {
             const expression = try self.parseSimpleExpression(raw_line, depth, false);
-            const value = self.getExpressionValue(expression);
+            var value = self.getExpressionValue(expression);
+
+            // Trim spaces to avoid errors when placing spaces after strings in the yaml
+            value = std.mem.trim(u8, value, " ");
 
             const isBooleanTrue = std.mem.eql(u8, value, "True") or std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "On") or std.mem.eql(u8, value, "on");
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -372,10 +372,7 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseStringExpression(self: *Self, raw_line: []const u8, depth: usize, is_multiline: bool) ![]const u8 {
             const expression = try self.parseSimpleExpression(raw_line, depth, is_multiline);
-            var value = self.getExpressionValue(expression);
-
-            // Trim spaces to avoid errors when placing spaces after strings in the yaml
-            value = std.mem.trim(u8, value, " ");
+            const value = self.getExpressionValueWithTrim(expression);
 
             if (value.len == 0) return value;
 
@@ -420,6 +417,17 @@ pub fn Ymlz(comptime Destination: type) type {
             return str;
         }
 
+        fn getExpressionValueWithTrim(self: *Self, expression: Expression) []const u8 {
+            _ = self;
+
+            // Trim spaces from value
+            return std.mem.trim(u8, switch (expression.value) {
+                .Simple => expression.value.Simple,
+                .KV => expression.value.KV.value,
+                else => @panic("Not implemeted for " ++ @typeName(@TypeOf(expression.value))),
+            }, " ");
+        }
+
         fn getExpressionValue(self: *Self, expression: Expression) []const u8 {
             _ = self;
 
@@ -432,10 +440,7 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseBooleanExpression(self: *Self, raw_line: []const u8, depth: usize) !bool {
             const expression = try self.parseSimpleExpression(raw_line, depth, false);
-            var value = self.getExpressionValue(expression);
-
-            // Trim spaces to avoid errors when placing spaces after strings in the yaml
-            value = std.mem.trim(u8, value, " ");
+            const value = self.getExpressionValueWithTrim(expression);
 
             const isBooleanTrue = std.mem.eql(u8, value, "True") or std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "On") or std.mem.eql(u8, value, "on");
 
@@ -454,9 +459,7 @@ pub fn Ymlz(comptime Destination: type) type {
 
         fn parseNumericExpression(self: *Self, comptime T: type, raw_line: []const u8, depth: usize) !T {
             const expression = try self.parseSimpleExpression(raw_line, depth, false);
-            var value = self.getExpressionValue(expression);
-
-            value = std.mem.trim(u8, value, " ");
+            const value = self.getExpressionValueWithTrim(expression);
 
             switch (@typeInfo(T)) {
                 .Int => {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -31,6 +31,9 @@ test "Multiple elements in yaml file" {
     try expect(result.elements[0].bool_val == true);
     try expect(std.mem.eql(u8, result.elements[0].name, "Example Name"));
 
+    // Ensure 1st element does *not* have spaces (A space is manually entered into the yaml file)
+    try expect(!std.mem.eql(u8, result.elements[0].name, "Example Name "));
+
     // Test 2nd element
     try expect(result.elements[1].bool_val == false);
     try expect(std.mem.eql(u8, result.elements[1].name, "Example Name 2"));

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4,6 +4,36 @@ const expect = std.testing.expect;
 
 const Ymlz = @import("root.zig").Ymlz;
 
+test "Multiple elements in yaml file" {
+    const MultiElement = struct {
+        name: []const u8,
+        bool_val: bool,
+    };
+
+    const Elements = struct { elements: []MultiElement };
+
+    const yml_file_location = try std.fs.cwd().realpathAlloc(
+        std.testing.allocator,
+        "./resources/yaml-test-suite/multiple_elements.yml",
+    );
+    defer std.testing.allocator.free(yml_file_location);
+
+    var ymlz = try Ymlz(Elements).init(std.testing.allocator);
+    const result = try ymlz.loadFile(yml_file_location);
+    defer ymlz.deinit(result);
+
+    // Ensure both elements are parsed as expected and we have 2
+    try expect(result.elements.len == 2);
+
+    // Test 1st element
+    try expect(result.elements[0].bool_val == true);
+    try expect(std.mem.eql(u8, result.elements[0].name, "Example Name"));
+
+    // Test 2nd element
+    try expect(result.elements[1].bool_val == false);
+    try expect(std.mem.eql(u8, result.elements[1].name, "Example Name 2"));
+}
+
 test "98YD" {
     const Element = struct {
         name: []const u8,
@@ -13,6 +43,9 @@ test "98YD" {
         tree: []const u8,
         json: []const u8,
         dump: []const u8,
+        bool_val: bool,
+        bool_val_2: bool,
+        bool_val_with_spaces: bool,
     };
 
     const Experiment = struct {
@@ -30,6 +63,11 @@ test "98YD" {
     defer ymlz.deinit(result);
 
     const element = result.elements[0];
+
+    // Test booleans
+    try expect(element.bool_val == true);
+    try expect(element.bool_val_2 == false);
+    try expect(element.bool_val_with_spaces == true);
 
     try expect(std.mem.eql(u8, element.name, "Spec Example 5.5. Comment Indicator"));
     // dump: ""

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8,13 +8,15 @@ test "Multiple elements in yaml file" {
     const MultiElement = struct {
         name: []const u8,
         bool_val: bool,
+        int_val: u8,
+        float_val: f64,
     };
 
     const Elements = struct { elements: []MultiElement };
 
     const yml_file_location = try std.fs.cwd().realpathAlloc(
         std.testing.allocator,
-        "./resources/yaml-test-suite/multiple_elements.yml",
+        "./resources/multiple_elements.yml",
     );
     defer std.testing.allocator.free(yml_file_location);
 
@@ -32,9 +34,17 @@ test "Multiple elements in yaml file" {
     // Test 2nd element
     try expect(result.elements[1].bool_val == false);
     try expect(std.mem.eql(u8, result.elements[1].name, "Example Name 2"));
+
+    // Test Ints
+    try expect(result.elements[0].int_val == 0);
+    try expect(result.elements[1].int_val == 120);
+
+    // Test floats
+    try expect(result.elements[0].float_val == 3.14);
+    try expect(result.elements[1].float_val == 56.123);
 }
 
-test "98YD" {
+test "98YD with bools" {
     const Element = struct {
         name: []const u8,
         from: []const u8,
@@ -54,7 +64,7 @@ test "98YD" {
 
     const yml_file_location = try std.fs.cwd().realpathAlloc(
         std.testing.allocator,
-        "./resources/yaml-test-suite/98YD.yml",
+        "./resources/yaml-test-suite/98YD-mixed.yml",
     );
     defer std.testing.allocator.free(yml_file_location);
 
@@ -68,6 +78,37 @@ test "98YD" {
     try expect(element.bool_val == true);
     try expect(element.bool_val_2 == false);
     try expect(element.bool_val_with_spaces == true);
+
+    try expect(std.mem.eql(u8, element.name, "Spec Example 5.5. Comment Indicator"));
+    try expect(element.dump.len == 0);
+}
+
+test "98YD" {
+    const Element = struct {
+        name: []const u8,
+        from: []const u8,
+        tags: []const u8,
+        yaml: []const u8,
+        tree: []const u8,
+        json: []const u8,
+        dump: []const u8,
+    };
+
+    const Experiment = struct {
+        elements: []Element,
+    };
+
+    const yml_file_location = try std.fs.cwd().realpathAlloc(
+        std.testing.allocator,
+        "./resources/yaml-test-suite/98YD.yml",
+    );
+    defer std.testing.allocator.free(yml_file_location);
+
+    var ymlz = try Ymlz(Experiment).init(std.testing.allocator);
+    const result = try ymlz.loadFile(yml_file_location);
+    defer ymlz.deinit(result);
+
+    const element = result.elements[0];
 
     try expect(std.mem.eql(u8, element.name, "Spec Example 5.5. Comment Indicator"));
     // dump: ""


### PR DESCRIPTION
Good day! I most enjoy the works you humans have curated for yaml parsing in Zig! I was glad to stumble upon your package the other day, which, so far, is working great for my needs. :smile: 

However, one thing I ran into was the following error when spaces were present after bool values in the yaml:
Error:
![Screenshot from 2024-09-14 14-19-52](https://github.com/user-attachments/assets/061e8852-6ac8-4b77-b5f5-b511ff548475)

Yaml with a space in it:
![Screenshot from 2024-09-14 14-20-07](https://github.com/user-attachments/assets/366a7b4a-9f14-45ca-8ae1-5a6a0c827273)

Now, it may be rare that this actually appears in the wild, but in my case I ran into it quick as my editor was adding spaces! Thus, I am be a fool, but it was fun to track down to discern where the error was coming from in your code. 

So I wanted to make a PR to do the following:
1. Fix the error and trim the spaces from the presented value when a bool or string expression.
2. Add some tests that included bools 
3. Add another test for displaying the use case of multiple values in a yaml file (since this is what I am using this for in a side project)

Quick screen shot of all tests passing as well:
![Screenshot from 2024-09-14 14-17-07](https://github.com/user-attachments/assets/b3a6c267-8810-4886-90d1-e7138d908ed9)

I bid you a grand day, let me know if anything is off here, always glad to adjust and accept any and all feedback! :bow: 