### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Easiest way to use ymlz is to fetch it via `zig fetch`, **make sure to provide i
 See an example below.
 
 ```bash
-zig fetch --save https://github.com/pwbh/ymlz/archive/refs/tags/0.1.0.tar.gz
+zig fetch --save https://github.com/pwbh/ymlz/archive/refs/tags/0.5.0.tar.gz
 ```
 
 Now in your `build.zig` we need to import ymlz as a module the following way:


### PR DESCRIPTION
Updating the ymlz version in zig fetch to latest current tag to match the code samples

I wanted to try out this repo, and the sample was not working, with an error about `loadRaw`. I thought this package was broken until I noticed I had a very old version of it. I changed it to 0.5.0, and it works fine so far.

the sample:
```
const std = @import("std");

const Ymlz = @import("root.zig").Ymlz;

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    const allocator = gpa.allocator();
    defer _ = gpa.deinit();

    const yaml_content =
        \\first: 500
        \\second: -3
        \\name: just testing strings overhere # just a comment
        \\fourth: 142.241
        \\# comment in between lines
        \\foods:
        \\  - Apple
        \\  - Orange
        \\  - Strawberry
        \\  - Mango
        \\inner:
        \\  abcd: 12
        \\  k: 2
        \\  l: hello world                 # comment somewhere
        \\  another:
        \\    new: 1
        \\    stringed: its just a string
    ;

    const Experiment = struct {
        first: i32,
        second: i64,
        name: []const u8,
        fourth: f32,
        foods: [][]const u8,
        inner: struct {
            abcd: i32,
            k: u8,
            l: []const u8,
            another: struct {
                new: f32,
                stringed: []const u8,
            },
        },
    };

    var ymlz = try Ymlz(Experiment).init(allocator);
    const result = try ymlz.loadRaw(yaml_content);
    defer ymlz.deinit(result);

    std.debug.print("Experiment.first: {}\n", .{result.first});
}
```

zig: 0.14.0

`zig build` output:

```
install
└─ install zig_sample_2
   └─ zig build-exe zig_sample_2 Debug native 1 errors
src/main.zig:48:28: error: no field or member function named 'loadRaw' in 'root.Ymlz(main.main.Experiment)'
    const result = try ymlz.loadRaw(yaml_content);
                       ~~~~^~~~~~~~
/home/fuad/.cache/zig/p/ymlz-0.1.0-AAAAAK5aAADGzW-2JKYiRnkTT-iki1iiox9KHK7qIcHA/src/root.zig:30:12: note: struct declared here
    return struct {
```

as it seems the method `loadRaw` was introduced in in version [0.3.0](https://github.com/pwbh/ymlz/releases/tag/0.3.0)